### PR TITLE
Fix building.

### DIFF
--- a/skprx/CMakeLists.txt
+++ b/skprx/CMakeLists.txt
@@ -27,6 +27,7 @@ add_executable(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
+        SceIofilemgrForDriver_stub
 	SceSysclibForDriver_stub
 	SceThreadmgrForDriver_stub
 	SceCpuForDriver_stub


### PR DESCRIPTION
With that line added, I was able to build it on my MSYS2 Windows 8.1 x64.

Without it
"undefined reference to `ksceIoMkdir'
undefined reference to blablabla"

So I just googled "vitasdk ksceIoMkdir", and found that you forgot to add needed lib.

```Using this library in your project

Include the header file in your project:
#include <psp2kern/io/stat.h> 

Link the library to the executable:
SceIofilemgrForDriver_stub 